### PR TITLE
feat: read config variables from parameter store (SRE-100)

### DIFF
--- a/stacklet/platform/cli/cli.py
+++ b/stacklet/platform/cli/cli.py
@@ -128,7 +128,7 @@ def auto_configure(ctx, prefix, location):
     try:
         param = json.loads(
             client.get_parameter(
-                Name=f"/{prefix}/platform/config", WithDecryption=True
+                Name=f"/stacklet/{prefix}/platform/config", WithDecryption=True
             )["Parameter"]["Value"]
         )
     except Exception as e:


### PR DESCRIPTION
we are moving the platform config to `/stacklet/${var.prefix}/platform/config`