### PR TITLE
fix: pass queries directly through graphql run

### DIFF
--- a/stacklet/client/platform/commands/graphql.py
+++ b/stacklet/client/platform/commands/graphql.py
@@ -4,7 +4,7 @@ import sys
 import click
 
 from stacklet.client.platform.executor import _run_graphql
-from stacklet.client.platform.graphql import StackletGraphqlSnippet
+from stacklet.client.platform.graphql import AdHocSnippet
 from stacklet.client.platform.utils import click_group_entry, default_options
 
 
@@ -31,4 +31,4 @@ def run(ctx, snippet):
 
 def _ad_hoc(snippet):
     "In practice, this is the most convenient way to create the subclass."
-    return type("AdHocSnippet", (StackletGraphqlSnippet,), {"snippet": snippet})
+    return type("AdHocSnippet", (AdHocSnippet,), {"snippet": snippet})

--- a/stacklet/client/platform/graphql.py
+++ b/stacklet/client/platform/graphql.py
@@ -92,6 +92,21 @@ class StackletGraphqlSnippet:
         return d
 
 
+class AdHocSnippet(StackletGraphqlSnippet):
+    """
+    This exists to work around the mangling in StackletGraphQLSnippet which
+    is inconvenient when trying to run simple queries that use e.g. quotes.
+
+    We can worry about variable support when we need it.
+    """
+
+    @classmethod
+    def build(cls, variables):
+        if variables:
+            raise NotImplementedError("AdHocSnippet needs variables support")
+        return {"query": cls.snippet}
+
+
 def gql_type(v, snippet_type=None):
     if snippet_type is not None:
         return snippet_type

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -73,7 +73,7 @@ class GraphqlTest(BaseCliTest):
     def test_graphql_executor_via_cli(self):
         executor, adapter = get_executor_adapter()
 
-        snippet = "{ platform { version } }"
+        snippet = '{ platform { dashboardDefinition(name:"cis-v140") } }'
         adapter.register_uri(
             "POST",
             "mock://stacklet.acme.org/api",


### PR DESCRIPTION
Was trying to use a snippet with quotes; it didn't work.

I'm not aware of a current use case where we'd want to transform a user-supplied snippet at all.