### PR TITLE
fix: pagination default value

### DIFF
--- a/stacklet/client/platform/utils.py
+++ b/stacklet/client/platform/utils.py
@@ -49,8 +49,8 @@ _PAGINATION_OPTIONS = {
         "default": 20,
     },
     "last": {
-        "help": "For use with pagination. Return the last n results.",
-        "default": 20,
+        "help": "For use with pagination. Return the last n results. Overrides first.",
+        "default": 0,
     },
     "before": {
         "help": "For use with pagination. Return the results before a given page cursor.",


### PR DESCRIPTION
We'd always send (first:20, last:20) and therefore only ever see the last page of results