### PR TITLE
fix: handle missing cubejs parameter.

### DIFF
--- a/stacklet/client/platform/config.py
+++ b/stacklet/client/platform/config.py
@@ -7,6 +7,8 @@ import os
 from jsonschema import ValidationError, validate
 from stacklet.client.platform.exceptions import ConfigValidationException
 
+MISSING = "missing"
+
 
 class StackletConfig:
 


### PR DESCRIPTION
For the platform functional tests we only install platform and executions.
The cubejs config param doesn't exist there.