### PR TITLE
chore: change log error to warning

### DIFF
--- a/stacklet/client/platform/cognito.py
+++ b/stacklet/client/platform/cognito.py
@@ -92,5 +92,5 @@ class CognitoUserManager:
             self.log.debug(res)
             return True
         except self.client.exceptions.ResourceNotFoundException:
-            self.log.error("Group:%s doesn't exist.", group)
+            self.log.warning("Group:%s doesn't exist.", group)
             return False


### PR DESCRIPTION
This shouldn't be logged as error since the CLI [makes it clear](https://github.com/stacklet/stacklet-admin/blob/15e91ea16b5293491646d760b6ab4298acf72808/stacklet/client/platform/commands/user.py#L48) that `ensure-group` will add a user to a group _if the group exists_.