### PR TITLE
fix: Explicitly name click objects that end with magic suffixes (ENG-5110)

### DIFF
--- a/stacklet/client/platform/commands/accountgroup.py
+++ b/stacklet/client/platform/commands/accountgroup.py
@@ -305,7 +305,7 @@ class RemoveAccountGroupItem(StackletGraphqlSnippet):
     parameter_types = {"provider": "CloudProvider!"}
 
 
-@click.group(short_help="Run account group queries/mutations")
+@click.group("account-group", short_help="Run account group queries/mutations")
 @default_options()
 @click.pass_context
 def account_group(*args, **kwargs):

--- a/stacklet/client/platform/commands/user.py
+++ b/stacklet/client/platform/commands/user.py
@@ -42,7 +42,7 @@ def add(ctx, username, password, email=None, phone_number=None, permanent=True):
         )
 
 
-@user.command()
+@user.command("ensure-group")
 @click.option("--username", required=True, help="the user to add to the group")
 @click.option(
     "--group", required=True, help="the group to add the user to (if it exists)"


### PR DESCRIPTION
[ENG-5110](https://stacklet.atlassian.net/browse/ENG-5110)

### what

Explicitly name click objects that end with magic suffixes

### why

Click 8.2.0 includes this change: "When generating a command’s name from a decorated function’s name, the suffixes _command, _cmd, _group, and _grp are removed.". That renamed our `user ensure-group` command to `user ensure`, and caused our `account-group` group to now clobber the `account` group.

poetry doesn't pull in 8.2.0 yet, as we support older Pythons than the new Click does. But this broke platform functional tests, which install directly through pip.

### testing

Manually, sadly. But platform ftests will verify it.


[ENG-5110]: https://stacklet.atlassian.net/browse/ENG-5110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ