### PR TITLE
chore: Use actions/upload-artifact@v4, as v3 has been removed

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
         run: poetry build
 
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-package-distributions
           path: dist/


### PR DESCRIPTION
### what

Use actions/upload-artifact@v4, as v3 has been removed

### why

See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
