### PR TITLE
chore: Release 0.1.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "stacklet.client.platform"
-version = "0.1.4"
+version = "0.1.5"
 description = "Stacklet Platform Client"
 readme = "README.md"
 authors = ["Sonny Shi <sonny@stacklet.io>"]


### PR DESCRIPTION
### what

Release 0.1.5

### why

#67 fixes an account, account-group and user command regression with click 8.2.0, so we should get it out there.

### testing

platform functional tests no longer fail.