### PR TITLE
feat: Add `system` as an output for account group info

### DIFF
--- a/stacklet/client/platform/graphql/snippets/account_group.py
+++ b/stacklet/client/platform/graphql/snippets/account_group.py
@@ -155,6 +155,7 @@ class ShowAccountGroup(GraphQLSnippet):
             provider
             description
             regions
+            system
             variables
             priority
             itemCount

--- a/stacklet/client/platform/graphql/snippets/account_group.py
+++ b/stacklet/client/platform/graphql/snippets/account_group.py
@@ -23,6 +23,7 @@ class ListAccountGroups(GraphQLSnippet):
                 provider
                 description
                 regions
+                system
                 variables
                 priority
                 itemCount


### PR DESCRIPTION
What
----

- Add `system` as an output for account group info

Why
---

- Useful for filtering out system groups when scripting.

Testing
-------

- [x] Manually tested while developing and using https://github.com/stacklet/platform/pull/3299

Docs
----

N/A
