### PR TITLE
chore: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,11 +8,17 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   Lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: wistia/parse-tool-versions@32f568a4ffd4bfa7720ebf93f171597d1ebc979a # v2.1.1
         with:
           postfix: _TOOL_VERSION
@@ -27,11 +33,15 @@ jobs:
   Tests:
     needs: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: wistia/parse-tool-versions@32f568a4ffd4bfa7720ebf93f171597d1ebc979a # v2.1.1
         with:
           postfix: _TOOL_VERSION

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,12 +2,18 @@ name: Publish Python distribution to PyPI
 
 on: push
 
+permissions: {}
+
 jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: wistia/parse-tool-versions@32f568a4ffd4bfa7720ebf93f171597d1ebc979a # v2.1.1
         with:
           postfix: _TOOL_VERSION
@@ -23,7 +29,9 @@ jobs:
           enable-cache: true
 
       - name: Install Python
-        run: uv python install ${{ env.PYTHON_TOOL_VERSION }}
+        env:
+          PYTHON_TOOL_VERSION: ${{ env.PYTHON_TOOL_VERSION }}
+        run: uv python install "$PYTHON_TOOL_VERSION"
 
       - name: Build a binary wheel and a source tarball
         run: uv build
@@ -84,10 +92,12 @@ jobs:
       - name: Upload artifact signatures to GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          REF_NAME: ${{ github.ref_name }}
+          REPOSITORY: ${{ github.repository }}
         # Upload to GitHub Release using the `gh` CLI.
         # `dist/` contains the built packages, and the
         # sigstore-produced signatures and certificates.
         run: >-
           gh release create
-          '${{ github.ref_name }}' dist/**
-          --repo '${{ github.repository }}'
+          "$REF_NAME" dist/**
+          --repo "$REPOSITORY"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,8 @@ repos:
     rev: v1.7.9
     hooks:
       - id: actionlint
+
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.19.0
+    hooks:
+      - id: zizmor


### PR DESCRIPTION
### what

- Add `permissions: {}` at workflow level for `ci.yaml` and
  `release.yaml` to remove default broad permissions
- Add `permissions: contents: read` at job level for the jobs that
  lacked explicit permissions (`Lint`, `Tests`, `build`)
- Add `persist-credentials: false` to all `actions/checkout` steps
- Fix template-injection in `release.yaml`: move
  `github.ref_name`, `github.repository`, and `PYTHON_TOOL_VERSION`
  out of inline `${{ }}` expansions and into `env:` blocks so they
  are passed as environment variables rather than interpolated
  directly into shell commands
- Add the `zizmor` pre-commit hook to `.pre-commit-config.yaml`

### why

`zizmor` and `actionlint` flagged several security issues:

- Default workflow permissions grant write access to all scopes;
  principle of least privilege requires explicit, minimal grants.
- `actions/checkout` persists a GitHub token in the local git
  config by default, which can be exfiltrated via artifacts if the
  runner is compromised.
- Inline `${{ github.ref_name }}` and similar expressions expand
  before the shell sees the command, enabling code injection if the
  value contains shell metacharacters. Binding them to environment
  variables prevents this.

Adding the pre-commit hook ensures these issues are caught locally
before a push.

### testing

- `zizmor .` reports zero findings after the changes.
- `actionlint` reports zero findings after the changes.

### docs

No docs needed.

---------------------------

🤖 Generated with [Claude Code](https://claude.com/claude-code)