### PR TITLE
fix: Migrate off deprecated GraphQL APIs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,25 @@
 
 ### Changes
 
+- **Migrated off deprecated GraphQL APIs**: `stacklet-admin` no longer uses GraphQL
+  fields/mutations that are deprecated in the platform schema. This includes some
+  breaking changes:
+  - `repository add` no longer accepts `--branch-name`, `--policy-file-suffix`,
+    `--policy-directory`, or `--deep-import` — the platform's replacement
+    `addRepositoryConfig` mutation no longer supports configuring these at
+    repository-creation time.
+  - `repository process`, `repository scan`, `repository remove`, and
+    `repository show` now take `--uuid` (the repository config UUID) instead of
+    `--url`. `repository scan` no longer accepts `--start-rev-spec`.
+  - `account-group add-item` no longer accepts `--provider` (implied by the
+    target account group).
+  - `account-group list/show/add/update/remove` and `policy-collection
+    list/show/add/update/add-item/remove-item/remove` now return account/policy
+    mappings (with a mapping id and pagination info) instead of the deprecated
+    flat `items`/`itemCount` fields.
+  - `binding` commands now return execution variables nested under
+    `executionConfig` instead of a top-level `variables` field.
+
 ### Fixes
 
 ---

--- a/stacklet/client/platform/commands/account_group.py
+++ b/stacklet/client/platform/commands/account_group.py
@@ -35,7 +35,10 @@ class _FindAccountGroupMapping(GraphQLSnippet):
     snippet = """
         query {
           accountGroup(uuid: $uuid) {
-            accountMappings(first: 1000) {
+            accountMappings(
+                first: 1000
+                after: $after
+            ) {
                 edges {
                     node {
                         id
@@ -45,28 +48,44 @@ class _FindAccountGroupMapping(GraphQLSnippet):
                         }
                     }
                 }
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
             }
           }
       }
     """
     required = {"uuid": "Account group UUID"}
+    optional = {"after": "Pagination cursor"}
 
 
 def _remove_item_pre_check(context: StackletContext, cli_args: dict[str, Any]) -> dict[str, Any]:
     """
     removeAccountGroupMappings needs the mapping's node id, but the CLI still accepts
-    the account's key/provider, so look up the id before running the mutation.
+    the account's key/provider, so look up the id before running the mutation. The
+    lookup pages through all mappings, since an account group can hold more than a
+    single page's worth.
     """
     group_uuid = cli_args["uuid"]
     key = cli_args["key"]
     provider = cli_args["provider"]
 
-    res = context.executor.run_snippet(_FindAccountGroupMapping, variables={"uuid": group_uuid})
-    edges = jmespath.search("data.accountGroup.accountMappings.edges", res) or []
-    for edge in edges:
-        account = edge["node"]["account"]
-        if account["key"] == key and account["provider"].upper() == provider.upper():
-            return {"mapping_id": edge["node"]["id"]}
+    after = None
+    while True:
+        res = context.executor.run_snippet(
+            _FindAccountGroupMapping, variables={"uuid": group_uuid, "after": after}
+        )
+        connection = jmespath.search("data.accountGroup.accountMappings", res) or {}
+        for edge in connection.get("edges") or []:
+            account = edge["node"]["account"]
+            if account["key"] == key and account["provider"].upper() == provider.upper():
+                return {"mapping_id": edge["node"]["id"]}
+
+        page_info = connection.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            break
+        after = page_info["endCursor"]
 
     raise InvalidInputException(
         f"No account with key={key!r} provider={provider!r} found in account group {group_uuid!r}"

--- a/stacklet/client/platform/commands/account_group.py
+++ b/stacklet/client/platform/commands/account_group.py
@@ -1,9 +1,15 @@
 # Copyright Stacklet, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-import click
+from typing import Any
 
+import click
+import jmespath
+
+from ..context import StackletContext
+from ..exceptions import InvalidInputException
 from ..graphql.cli import GraphQLCommand, register_graphql_commands
+from ..graphql.snippet import GraphQLSnippet
 from ..graphql.snippets import (
     AddAccountGroup,
     AddAccountGroupItem,
@@ -22,6 +28,51 @@ def account_group(*args, **kwargs):
     """
 
 
+class _FindAccountGroupMapping(GraphQLSnippet):
+    """Internal lookup used to resolve a mapping id from an account key/provider."""
+
+    name = "_find-account-group-mapping"
+    snippet = """
+        query {
+          accountGroup(uuid: $uuid) {
+            accountMappings(first: 1000) {
+                edges {
+                    node {
+                        id
+                        account {
+                            key
+                            provider
+                        }
+                    }
+                }
+            }
+          }
+      }
+    """
+    required = {"uuid": "Account group UUID"}
+
+
+def _remove_item_pre_check(context: StackletContext, cli_args: dict[str, Any]) -> dict[str, Any]:
+    """
+    removeAccountGroupMappings needs the mapping's node id, but the CLI still accepts
+    the account's key/provider, so look up the id before running the mutation.
+    """
+    group_uuid = cli_args["uuid"]
+    key = cli_args["key"]
+    provider = cli_args["provider"]
+
+    res = context.executor.run_snippet(_FindAccountGroupMapping, variables={"uuid": group_uuid})
+    edges = jmespath.search("data.accountGroup.accountMappings.edges", res) or []
+    for edge in edges:
+        account = edge["node"]["account"]
+        if account["key"] == key and account["provider"].upper() == provider.upper():
+            return {"mapping_id": edge["node"]["id"]}
+
+    raise InvalidInputException(
+        f"No account with key={key!r} provider={provider!r} found in account group {group_uuid!r}"
+    )
+
+
 register_graphql_commands(
     account_group,
     [
@@ -31,6 +82,11 @@ register_graphql_commands(
         GraphQLCommand("show", ShowAccountGroup, "Show account group"),
         GraphQLCommand("remove", RemoveAccountGroup, "Remove account group"),
         GraphQLCommand("add-item", AddAccountGroupItem, "Add account group item"),
-        GraphQLCommand("remove-item", RemoveAccountGroupItem, "Remove account group item"),
+        GraphQLCommand(
+            "remove-item",
+            RemoveAccountGroupItem,
+            "Remove account group item",
+            pre_check=_remove_item_pre_check,
+        ),
     ],
 )

--- a/stacklet/client/platform/graphql/snippets/account_group.py
+++ b/stacklet/client/platform/graphql/snippets/account_group.py
@@ -26,7 +26,11 @@ class ListAccountGroups(GraphQLSnippet):
                 system
                 variables
                 priority
-                itemCount
+                accountMappings(first: 0) {
+                    pageInfo {
+                        total
+                    }
+                }
               }
             }
             pageInfo {
@@ -66,13 +70,21 @@ class AddAccountGroup(GraphQLSnippet):
             regions
             variables
             priority
-            itemCount
-            items {
-                uuid
-                key
-                provider
-                name
-                regions
+            accountMappings(first: 1000) {
+                edges {
+                    node {
+                        id
+                        regions
+                        account {
+                            key
+                            provider
+                            name
+                        }
+                    }
+                }
+                pageInfo {
+                    total
+                }
             }
         }
       }
@@ -118,13 +130,21 @@ class UpdateAccountGroup(GraphQLSnippet):
             regions
             variables
             priority
-            itemCount
-            items {
-                uuid
-                key
-                provider
-                name
-                regions
+            accountMappings(first: 1000) {
+                edges {
+                    node {
+                        id
+                        regions
+                        account {
+                            key
+                            provider
+                            name
+                        }
+                    }
+                }
+                pageInfo {
+                    total
+                }
             }
         }
       }
@@ -158,13 +178,21 @@ class ShowAccountGroup(GraphQLSnippet):
             system
             variables
             priority
-            itemCount
-            items {
-                uuid
-                key
-                provider
-                name
-                regions
+            accountMappings(first: 1000) {
+                edges {
+                    node {
+                        id
+                        regions
+                        account {
+                            key
+                            provider
+                            name
+                        }
+                    }
+                }
+                pageInfo {
+                    total
+                }
             }
           }
       }
@@ -189,13 +217,21 @@ class RemoveAccountGroup(GraphQLSnippet):
                 regions
                 variables
                 priority
-                itemCount
-                items {
-                    uuid
-                    key
-                    provider
-                    name
-                    regions
+                accountMappings(first: 1000) {
+                    edges {
+                        node {
+                            id
+                            regions
+                            account {
+                                key
+                                provider
+                                name
+                            }
+                        }
+                    }
+                    pageInfo {
+                        total
+                    }
                 }
             }
           }
@@ -208,32 +244,26 @@ class AddAccountGroupItem(GraphQLSnippet):
     name = "add-account-group-item"
     snippet = """
         mutation {
-          addAccountGroupItems(input:{
-            uuid: $uuid
-            items: [
+          upsertAccountGroupMappings(input:{
+            mappings: [
                 {
-                    key: $key
-                    provider: $provider
+                    accountKey: $key
+                    groupUUID: $uuid
+                    regions: $regions
                 }
             ]
           }) {
-              group {
-                name
-                uuid
+              mappings {
                 id
-                shortName
-                provider
-                description
                 regions
-                variables
-                priority
-                itemCount
-                items {
-                    uuid
+                account {
                     key
                     provider
                     name
-                    regions
+                }
+                group {
+                    uuid
+                    name
                 }
             }
           }
@@ -242,43 +272,19 @@ class AddAccountGroupItem(GraphQLSnippet):
     required = {
         "uuid": "Account group UUID",
         "key": "Account Key",
-        "provider": "Account Provider",
     }
-    optional = {"regions": "Account Regions"}
-    parameter_types = {"provider": "CloudProvider!"}
+    optional = {"regions": {"help": "Account Regions", "multiple": True}}
 
 
 class RemoveAccountGroupItem(GraphQLSnippet):
     name = "remove-account-group-item"
     snippet = """
         mutation {
-          removeAccountGroupItems(input:{
-            uuid: $uuid
-            items: [
-                {
-                    key: $key
-                    provider: $provider
-                }
-            ]
+          removeAccountGroupMappings(input:{
+            ids: [$mapping_id]
           }) {
-              group {
-                name
-                uuid
+              removed {
                 id
-                shortName
-                provider
-                description
-                regions
-                variables
-                priority
-                itemCount
-                items {
-                    uuid
-                    key
-                    provider
-                    name
-                    regions
-                }
             }
           }
       }
@@ -288,4 +294,4 @@ class RemoveAccountGroupItem(GraphQLSnippet):
         "key": "Account Key",
         "provider": "Account Provider",
     }
-    parameter_types = {"provider": "CloudProvider!"}
+    parameter_types = {"mapping_id": "ID!"}

--- a/stacklet/client/platform/graphql/snippets/binding.py
+++ b/stacklet/client/platform/graphql/snippets/binding.py
@@ -20,7 +20,9 @@ class ListBindings(GraphQLSnippet):
                 name
                 description
                 schedule
-                variables
+                executionConfig {
+                    variables
+                }
                 lastDeployed
                 system
                 accountGroup {
@@ -58,7 +60,9 @@ class ShowBinding(GraphQLSnippet):
             name
             description
             schedule
-            variables
+            executionConfig {
+                variables
+            }
             lastDeployed
             system
             accountGroup {
@@ -86,7 +90,7 @@ class AddBinding(GraphQLSnippet):
             policyCollectionUUID: $policy_collection_uuid
             description: $description
             schedule: $schedule
-            variables: $variables
+            executionConfig: { variables: $variables }
             deploy: $deploy
         }){
             binding {
@@ -94,7 +98,9 @@ class AddBinding(GraphQLSnippet):
                 name
                 description
                 schedule
-                variables
+                executionConfig {
+                    variables
+                }
                 lastDeployed
                 accountGroup {
                     uuid
@@ -132,14 +138,16 @@ class UpdateBinding(GraphQLSnippet):
             name: $name
             description: $description
             schedule: $schedule
-            variables: $variables
+            executionConfig: { variables: $variables }
         }){
             binding {
                 uuid
                 name
                 description
                 schedule
-                variables
+                executionConfig {
+                    variables
+                }
                 lastDeployed
                 accountGroup {
                     uuid
@@ -175,7 +183,9 @@ class RemoveBinding(GraphQLSnippet):
                 name
                 description
                 schedule
-                variables
+                executionConfig {
+                    variables
+                }
                 lastDeployed
                 accountGroup {
                     uuid
@@ -202,7 +212,9 @@ class DeployBinding(GraphQLSnippet):
                 name
                 description
                 schedule
-                variables
+                executionConfig {
+                    variables
+                }
                 lastDeployed
                 accountGroup {
                     uuid
@@ -230,7 +242,9 @@ class RunBinding(GraphQLSnippet):
                 name
                 description
                 schedule
-                variables
+                executionConfig {
+                    variables
+                }
                 lastDeployed
                 accountGroup {
                     uuid

--- a/stacklet/client/platform/graphql/snippets/policy_collection.py
+++ b/stacklet/client/platform/graphql/snippets/policy_collection.py
@@ -22,7 +22,11 @@ class ListPolicyCollections(GraphQLSnippet):
                 description
                 provider
                 repository
-                itemCount
+                policyMappings(first: 0) {
+                    pageInfo {
+                        total
+                    }
+                }
               }
             }
             pageInfo {
@@ -52,11 +56,20 @@ class ShowPolicyCollection(GraphQLSnippet):
             description
             provider
             repository
-            itemCount
-            items {
-                uuid
-                name
-                version
+            policyMappings(first: 1000) {
+                edges {
+                    node {
+                        id
+                        policy {
+                            uuid
+                            name
+                            version
+                        }
+                    }
+                }
+                pageInfo {
+                    total
+                }
             }
           }
       }
@@ -81,11 +94,20 @@ class AddPolicyCollection(GraphQLSnippet):
             description
             provider
             repository
-            itemCount
-            items {
-                uuid
-                name
-                version
+            policyMappings(first: 1000) {
+                edges {
+                    node {
+                        id
+                        policy {
+                            uuid
+                            name
+                            version
+                        }
+                    }
+                }
+                pageInfo {
+                    total
+                }
             }
         }
       }
@@ -120,11 +142,20 @@ class UpdatePolicyCollection(GraphQLSnippet):
             description
             provider
             repository
-            itemCount
-            items {
-                uuid
-                name
-                version
+            policyMappings(first: 1000) {
+                edges {
+                    node {
+                        id
+                        policy {
+                            uuid
+                            name
+                            version
+                        }
+                    }
+                }
+                pageInfo {
+                    total
+                }
             }
         }
       }
@@ -159,11 +190,20 @@ class AddPolicyCollectionItem(GraphQLSnippet):
                 description
                 provider
                 repository
-                itemCount
-                items {
-                    uuid
-                    name
-                    version
+                policyMappings(first: 1000) {
+                    edges {
+                        node {
+                            id
+                            policy {
+                                uuid
+                                name
+                                version
+                            }
+                        }
+                    }
+                    pageInfo {
+                        total
+                    }
                 }
             }
           }
@@ -198,11 +238,20 @@ class RemovePolicyCollectionItem(GraphQLSnippet):
                 description
                 provider
                 repository
-                itemCount
-                items {
-                    uuid
-                    name
-                    version
+                policyMappings(first: 1000) {
+                    edges {
+                        node {
+                            id
+                            policy {
+                                uuid
+                                name
+                                version
+                            }
+                        }
+                    }
+                    pageInfo {
+                        total
+                    }
                 }
             }
           }
@@ -230,11 +279,20 @@ class RemovePolicyCollection(GraphQLSnippet):
             description
             provider
             repository
-            itemCount
-            items {
-                uuid
-                name
-                version
+            policyMappings(first: 1000) {
+                edges {
+                    node {
+                        id
+                        policy {
+                            uuid
+                            name
+                            version
+                        }
+                    }
+                }
+                pageInfo {
+                    total
+                }
             }
         }
       }

--- a/stacklet/client/platform/graphql/snippets/repository.py
+++ b/stacklet/client/platform/graphql/snippets/repository.py
@@ -8,24 +8,27 @@ class AddRepository(GraphQLSnippet):
     name = "add-repository"
     snippet = """
     mutation {
-      addRepository(
+      addRepositoryConfig(
         input: {
           url: $url
           name: $name
           description: $description
-          sshPassphrase: $ssh_passphrase
-          sshPrivateKey: $ssh_private_key
-          authUser: $auth_user
-          authToken: $auth_token
-          branchName: $branch_name
-          policyFileSuffix: $policy_file_suffix
-          policyDirectories: $policy_directory
-          deepImport: $deep_import
+          auth: {
+            authUser: $auth_user
+            authToken: $auth_token
+            sshPrivateKey: $ssh_private_key
+            sshPassphrase: $ssh_passphrase
+          }
+          webhookSecret: $webhook_secret
         }
       ) {
-        repository {
+        repositoryConfig {
+            uuid
             url
             name
+        }
+        problems {
+            message
         }
       }
     }
@@ -41,49 +44,64 @@ class AddRepository(GraphQLSnippet):
         "ssh_private_key": "Path to a SSH Private Key",
         "auth_user": "Auth User for repository access",
         "auth_token": "Auth token for repository access",
-        "branch_name": "Git Branch Name",
-        "policy_file_suffix": {
-            "help": 'List of Policy File Suffixes e.g. [".json", ".yaml", ".yml"]',
-            "multiple": True,
-        },
-        "policy_directory": {
-            "help": 'Policy Directories e.g. ["policies", "some/path"]',
-            "multiple": True,
-        },
-        "deep_import": "Deep Import Repository true | false",
+        "webhook_secret": "Secret used to validate repository webhook payloads",
     }
-    variable_transformers = {"deep_import": lambda x: x and x.lower() in ("true", "t", "yes", "y")}
-    result_expr = "data.addRepository.repository"
+    result_expr = "data.addRepositoryConfig.repositoryConfig"
 
 
 class ProcessRepository(GraphQLSnippet):
     name = "process-repository"
     snippet = """
     mutation {
-      processRepository(input:{url: $url})
+      triggerRepositoryScan(input:{uuid: $uuid}) {
+        problems {
+            message
+        }
+      }
     }
     """
-    required = {"url": "Repository URL to process"}
+    required = {"uuid": "Repository Config UUID"}
+    result_expr = "data.triggerRepositoryScan"
+
+
+class ScanRepository(GraphQLSnippet):
+    name = "scan-repository"
+    snippet = """
+    mutation {
+      triggerRepositoryScan(input:{uuid: $uuid}) {
+        problems {
+            message
+        }
+      }
+    }
+    """
+    required = {"uuid": "Repository Config UUID"}
+    result_expr = "data.triggerRepositoryScan"
 
 
 class ListRepository(GraphQLSnippet):
     name = "list-repository"
     snippet = """
     query {
-      repositories {
+      repositoryConfigs {
         edges {
           node {
             id
+            uuid
             name
             url
-            policyFileSuffix
-            policyDirectories
-            branchName
-            authUser
-            sshPublicKey
-            head
-            lastScanned
             provider
+            auth {
+                authUser
+                sshPublicKey
+            }
+            globalView {
+                branchName
+                policyFileSuffix
+                policyDirectories
+                head
+                lastScanned
+            }
           }
         }
         pageInfo {
@@ -96,86 +114,126 @@ class ListRepository(GraphQLSnippet):
       }
     }
     """
-    result_expr = "data.repositories.edges[].node"
+    result_expr = "data.repositoryConfigs.edges[].node"
 
 
 class RemoveRepository(GraphQLSnippet):
     name = "remove-repository"
     snippet = """
     mutation {
-      removeRepository(
-          url: $url
+      removeRepositoryConfig(
+          input: {
+              uuid: $uuid
+              cascade: $cascade
+          }
       ) {
-        repository {
-            url
-            name
+        removed {
+            id
+        }
+        problems {
+            message
         }
       }
     }
     """
     required = {
-        "url": "Policy Repository URL",
+        "uuid": "Repository Config UUID",
     }
-    result_expr = "data.removeRepository.repository"
-
-
-class ScanRepository(GraphQLSnippet):
-    name = "scan-repository"
-    snippet = """
-    mutation {
-      processRepository(input:{
-          url: $url
-          startRevSpec: $start_rev_spec
-      })
+    optional = {
+        "cascade": {
+            "help": (
+                "Also remove bindings and policy collections tied to this repository (true|false)"
+            ),
+            "default": "false",
+        },
     }
-    """
-    required = {
-        "url": "Policy Repository URL",
+    variable_transformers = {
+        "cascade": lambda x: x is not None and x.lower() in ("true", "t", "yes", "y")
     }
-
-    optional = {"start_rev_spec": "Start Rev Spec"}
+    result_expr = "data.removeRepositoryConfig"
 
 
 class ShowRepository(GraphQLSnippet):
     name = "show-repository"
     snippet = """
     query {
-      repository(url: $url) {
-        id
-        name
-        url
-        policyFileSuffix
-        policyDirectories
-        branchName
-        authUser
-        sshPublicKey
-        head
-        lastScanned
-        provider
-        scans {
-          edges {
-            node {
-              started
-              completed
-              head
-              error
-              commitsProcessed
-              policiesAdded
-              policiesModified
-              policiesRemoved
-              policiesInvalid
+      repositoryConfig(uuid: $uuid) {
+        repositoryConfig {
+            id
+            uuid
+            name
+            url
+            provider
+            webhookURL
+            hasWebhookSecret
+            created
+            modified
+            auth {
+                authUser
+                sshPublicKey
+                hasAuthToken
+                hasSshPrivateKey
+                hasSshPassphrase
+                connectStatus
+                connectError
             }
-          }
-          pageInfo {
-            hasPreviousPage
-            hasNextPage
-            startCursor
-            endCursor
-            total
-          }
+            globalView {
+                uuid
+                branchName
+                policyFileSuffix
+                policyDirectories
+                head
+                lastScanned
+                scans {
+                    edges {
+                        node {
+                            started
+                            completed
+                            head
+                            errors {
+                                ... on SimpleScanError {
+                                    type
+                                    messages
+                                }
+                                ... on DuplicatePolicyError {
+                                    type
+                                    policyName
+                                    path
+                                    otherRepository
+                                    otherPath
+                                    commitHash
+                                }
+                                ... on DashboardError {
+                                    type
+                                    issues {
+                                        title
+                                        message
+                                    }
+                                }
+                            }
+                            commitsProcessed
+                            policiesAdded
+                            policiesModified
+                            policiesRemoved
+                            policiesInvalid
+                        }
+                    }
+                    pageInfo {
+                        hasPreviousPage
+                        hasNextPage
+                        startCursor
+                        endCursor
+                        total
+                    }
+                }
+            }
+        }
+        problems {
+            message
         }
       }
     }
     """
 
-    required = {"url": "Repository URL to process"}
+    required = {"uuid": "Repository Config UUID"}
+    result_expr = "data.repositoryConfig.repositoryConfig"

--- a/tests/test_account_group.py
+++ b/tests/test_account_group.py
@@ -1,0 +1,177 @@
+# Copyright Stacklet, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+from .asserts import assert_query
+
+
+class TestAccountGroup:
+    def test_add_item(self, run_query):
+        res, body = run_query(
+            "account-group",
+            [
+                "add-item",
+                "--uuid=11111111-1111-1111-1111-111111111111",
+                "--key=123456789012",
+            ],
+            response={
+                "data": {
+                    "upsertAccountGroupMappings": {
+                        "mappings": [
+                            {
+                                "id": "mapping:1",
+                                "regions": None,
+                                "account": {
+                                    "key": "123456789012",
+                                    "provider": "AWS",
+                                    "name": "test-account",
+                                },
+                                "group": {
+                                    "uuid": "11111111-1111-1111-1111-111111111111",
+                                    "name": "test-group",
+                                },
+                            }
+                        ]
+                    }
+                }
+            },
+        )
+        assert res.exit_code == 0
+        assert_query(
+            body,
+            """
+            mutation ($uuid: String!, $key: String!) {
+              upsertAccountGroupMappings(input:{
+                mappings: [
+                    {
+                        accountKey: $key
+                        groupUUID: $uuid
+                    }
+                ]
+              }) {
+                  mappings {
+                    id
+                    regions
+                    account {
+                        key
+                        provider
+                        name
+                    }
+                    group {
+                        uuid
+                        name
+                    }
+                }
+              }
+          }
+            """,
+        )
+        assert body["variables"] == {
+            "uuid": "11111111-1111-1111-1111-111111111111",
+            "key": "123456789012",
+        }
+
+    def test_remove_item(self, requests_adapter, sample_config_file, api_token_in_file, invoke_cli):
+        """removeAccountGroupMappings needs a mapping id, so removal is a lookup then a mutation."""
+        requests_adapter.register_uri(
+            "POST",
+            "mock://stacklet.acme.org/api",
+            [
+                {
+                    "json": {
+                        "data": {
+                            "accountGroup": {
+                                "accountMappings": {
+                                    "edges": [
+                                        {
+                                            "node": {
+                                                "id": "mapping:1",
+                                                "account": {
+                                                    "key": "123456789012",
+                                                    "provider": "AWS",
+                                                },
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "json": {
+                        "data": {"removeAccountGroupMappings": {"removed": [{"id": "mapping:1"}]}}
+                    }
+                },
+            ],
+        )
+
+        res = invoke_cli(
+            "account-group",
+            "remove-item",
+            "--uuid=11111111-1111-1111-1111-111111111111",
+            "--key=123456789012",
+            "--provider=AWS",
+        )
+        assert res.exit_code == 0, res.output
+
+        requests = [json.loads(r.body.decode()) for r in requests_adapter.request_history]
+        assert len(requests) == 2
+
+        assert_query(
+            requests[0],
+            """
+            query ($uuid: String!) {
+              accountGroup(uuid: $uuid) {
+                accountMappings(first: 1000) {
+                    edges {
+                        node {
+                            id
+                            account {
+                                key
+                                provider
+                            }
+                        }
+                    }
+                }
+              }
+          }
+            """,
+        )
+        assert requests[0]["variables"] == {"uuid": "11111111-1111-1111-1111-111111111111"}
+
+        assert_query(
+            requests[1],
+            """
+            mutation ($mapping_id: ID!) {
+              removeAccountGroupMappings(input:{
+                ids: [$mapping_id]
+              }) {
+                  removed {
+                    id
+                }
+              }
+          }
+            """,
+        )
+        assert requests[1]["variables"] == {"mapping_id": "mapping:1"}
+
+    def test_remove_item_not_found(
+        self, requests_adapter, sample_config_file, api_token_in_file, invoke_cli
+    ):
+        requests_adapter.register_uri(
+            "POST",
+            "mock://stacklet.acme.org/api",
+            json={"data": {"accountGroup": {"accountMappings": {"edges": []}}}},
+        )
+
+        res = invoke_cli(
+            "account-group",
+            "remove-item",
+            "--uuid=11111111-1111-1111-1111-111111111111",
+            "--key=123456789012",
+            "--provider=AWS",
+        )
+        assert res.exit_code != 0
+        assert "No account with key" in res.output

--- a/tests/test_account_group.py
+++ b/tests/test_account_group.py
@@ -93,7 +93,8 @@ class TestAccountGroup:
                                                 },
                                             }
                                         }
-                                    ]
+                                    ],
+                                    "pageInfo": {"hasNextPage": False, "endCursor": None},
                                 }
                             }
                         }
@@ -124,7 +125,9 @@ class TestAccountGroup:
             """
             query ($uuid: String!) {
               accountGroup(uuid: $uuid) {
-                accountMappings(first: 1000) {
+                accountMappings(
+                    first: 1000
+                ) {
                     edges {
                         node {
                             id
@@ -133,6 +136,10 @@ class TestAccountGroup:
                                 provider
                             }
                         }
+                    }
+                    pageInfo {
+                        hasNextPage
+                        endCursor
                     }
                 }
               }
@@ -156,6 +163,84 @@ class TestAccountGroup:
             """,
         )
         assert requests[1]["variables"] == {"mapping_id": "mapping:1"}
+
+    def test_remove_item_paginates(
+        self, requests_adapter, sample_config_file, api_token_in_file, invoke_cli
+    ):
+        """The lookup must page through accountMappings, not just the first page."""
+        requests_adapter.register_uri(
+            "POST",
+            "mock://stacklet.acme.org/api",
+            [
+                {
+                    "json": {
+                        "data": {
+                            "accountGroup": {
+                                "accountMappings": {
+                                    "edges": [
+                                        {
+                                            "node": {
+                                                "id": "mapping:1",
+                                                "account": {
+                                                    "key": "111111111111",
+                                                    "provider": "AWS",
+                                                },
+                                            }
+                                        }
+                                    ],
+                                    "pageInfo": {"hasNextPage": True, "endCursor": "cursor-1"},
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "json": {
+                        "data": {
+                            "accountGroup": {
+                                "accountMappings": {
+                                    "edges": [
+                                        {
+                                            "node": {
+                                                "id": "mapping:2",
+                                                "account": {
+                                                    "key": "222222222222",
+                                                    "provider": "AWS",
+                                                },
+                                            }
+                                        }
+                                    ],
+                                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "json": {
+                        "data": {"removeAccountGroupMappings": {"removed": [{"id": "mapping:2"}]}}
+                    }
+                },
+            ],
+        )
+
+        res = invoke_cli(
+            "account-group",
+            "remove-item",
+            "--uuid=11111111-1111-1111-1111-111111111111",
+            "--key=222222222222",
+            "--provider=AWS",
+        )
+        assert res.exit_code == 0, res.output
+
+        requests = [json.loads(r.body.decode()) for r in requests_adapter.request_history]
+        assert len(requests) == 3
+        assert requests[0]["variables"] == {"uuid": "11111111-1111-1111-1111-111111111111"}
+        assert requests[1]["variables"] == {
+            "uuid": "11111111-1111-1111-1111-111111111111",
+            "after": "cursor-1",
+        }
+        assert requests[2]["variables"] == {"mapping_id": "mapping:2"}
 
     def test_remove_item_not_found(
         self, requests_adapter, sample_config_file, api_token_in_file, invoke_cli

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -17,9 +17,13 @@ class TestRepository:
             ],
             response={
                 "data": {
-                    "addRepository": {
-                        "url": "mock://git.acme.org/stacklet/policies.git",
-                        "name": "test-policies",
+                    "addRepositoryConfig": {
+                        "repositoryConfig": {
+                            "uuid": "34c10c3e-d841-4e63-9d51-01b92f36c502",
+                            "url": "mock://git.acme.org/stacklet/policies.git",
+                            "name": "test-policies",
+                        },
+                        "problems": [],
                     }
                 }
             },
@@ -27,9 +31,12 @@ class TestRepository:
         assert res.output == dedent(
             """\
             data:
-              addRepository:
-                name: test-policies
-                url: mock://git.acme.org/stacklet/policies.git
+              addRepositoryConfig:
+                problems: []
+                repositoryConfig:
+                  name: test-policies
+                  url: mock://git.acme.org/stacklet/policies.git
+                  uuid: 34c10c3e-d841-4e63-9d51-01b92f36c502
 
             """
         )
@@ -38,73 +45,83 @@ class TestRepository:
             body,
             """
             mutation ($url: String!, $name: String!) {
-              addRepository(
+              addRepositoryConfig(
                 input: {
                   url: $url
                   name: $name
+                  auth: {
+                  }
                 }
               ) {
-                repository {
-                  url
-                  name
+                repositoryConfig {
+                    uuid
+                    url
+                    name
+                }
+                problems {
+                    message
                 }
               }
             }
             """,
         )
 
-    def test_add_repository_deep(self, run_query):
+    def test_add_repository_with_auth(self, run_query):
         res, body = run_query(
             "repository",
             [
                 "add",
                 "--url=mock://git.acme.org/stacklet/policies.git",
                 "--name=test-policies",
-                "--deep-import=true",
+                "--auth-user=someuser",
+                "--auth-token=sometoken",
             ],
             response={
                 "data": {
-                    "addRepository": {
-                        "url": "mock://git.acme.org/stacklet/policies.git",
-                        "name": "test-policies",
+                    "addRepositoryConfig": {
+                        "repositoryConfig": {
+                            "uuid": "34c10c3e-d841-4e63-9d51-01b92f36c502",
+                            "url": "mock://git.acme.org/stacklet/policies.git",
+                            "name": "test-policies",
+                        },
+                        "problems": [],
                     }
                 }
             },
         )
-        assert res.output == dedent(
-            """\
-            data:
-              addRepository:
-                name: test-policies
-                url: mock://git.acme.org/stacklet/policies.git
-
-            """
-        )
+        assert res.exit_code == 0
 
         assert_query(
             body,
             """
-            mutation ($url: String!, $name: String!, $deep_import: Boolean!) {
-              addRepository(
+            mutation ($url: String!, $name: String!, $auth_user: String!, $auth_token: String!) {
+              addRepositoryConfig(
                 input: {
                   url: $url
                   name: $name
-                  deepImport: $deep_import
+                  auth: {
+                    authUser: $auth_user
+                    authToken: $auth_token
+                  }
                 }
               ) {
-                repository {
-                  url
-                  name
+                repositoryConfig {
+                    uuid
+                    url
+                    name
+                }
+                problems {
+                    message
                 }
               }
             }
             """,
         )
-        # Check the conversion of string to bool.
         assert body["variables"] == {
-            "deep_import": True,
-            "name": "test-policies",
             "url": "mock://git.acme.org/stacklet/policies.git",
+            "name": "test-policies",
+            "auth_user": "someuser",
+            "auth_token": "sometoken",
         }
 
     def test_process_repository(self, run_query):
@@ -112,16 +129,20 @@ class TestRepository:
             "repository",
             [
                 "process",
-                "--url=mock://git.acme.org/stacklet/policies.git",
+                "--uuid=34c10c3e-d841-4e63-9d51-01b92f36c502",
             ],
-            response={"data": {"processRepository": "34c10c3e-d841-4e63-9d51-01b92f36c502"}},
+            response={"data": {"triggerRepositoryScan": {"problems": []}}},
         )
-        assert res.output == "data:\n  processRepository: 34c10c3e-d841-4e63-9d51-01b92f36c502\n\n"
+        assert res.output == "data:\n  triggerRepositoryScan:\n    problems: []\n\n"
         assert_query(
             body,
             """
-            mutation ($url: String!) {
-              processRepository(input:{url: $url})
+            mutation ($uuid: String!) {
+              triggerRepositoryScan(input:{uuid: $uuid}) {
+                problems {
+                    message
+                }
+              }
             }
             """,
         )


### PR DESCRIPTION
## Summary

- Migrates `stacklet-admin` off GraphQL fields/mutations marked `@deprecated` in the platform schema, across the repository, account-group, policy-collection, and binding domains.
- `repository` commands move from the legacy `repository`/`repositories`/`addRepository`/`removeRepository`/`processRepository` API to `repositoryConfig`/`repositoryConfigs`/`addRepositoryConfig`/`removeRepositoryConfig`/`triggerRepositoryScan`. As a result:
  - `repository add` drops `--branch-name`, `--policy-file-suffix`, `--policy-directory`, `--deep-import` (no longer accepted by `addRepositoryConfig`).
  - `repository process`/`scan`/`show`/`remove` take `--uuid` instead of `--url`; `repository scan` drops `--start-rev-spec`.
- `account-group` commands move `AccountGroup.items`/`itemCount` to `accountMappings`, and `addAccountGroupItems`/`removeAccountGroupItems` to `upsertAccountGroupMappings`/`removeAccountGroupMappings`. `remove-item` keeps its existing `--uuid`/`--key`/`--provider` interface via an internal mapping-id lookup (paginated, so it works past the first page), since the new mutation needs an opaque mapping id. `add-item` drops `--provider` (unused by the new mutation).
- `policy-collection` commands move `PolicyCollection.items`/`itemCount` to `policyMappings` (the `add-item`/`remove-item` mutations themselves were not deprecated, so no CLI interface change there).
- `binding` commands move the deprecated top-level `variables` arg/field to the structured `executionConfig { variables }`.
- Account and policy commands needed no changes.

## Test plan

- [x] `uv run pytest tests/` — 90 passed
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run ty check stacklet/`
- [x] `uv run deptry .`
- [x] **Manual verification against a live local platform deploy** (not just mocked unit tests):
  - `repository list` / `repository show` — confirmed real `RepositoryConfig` data comes back correctly shaped via `repositoryConfigs`/`repositoryConfig`.
  - `policy-collection list` — confirmed `policyMappings.pageInfo` shape.
  - `account-group add` (with `--region`), `add-item`, `show` — confirmed the new `accountMappings` shape end-to-end (create group → add mapping → verify mapping visible).
  - `account-group remove-item` — confirmed the mapping-id lookup pre-check resolves correctly and the mapping is actually removed (this is the path fixed for pagination per Greptile's review comment on this PR).
  - `account-group remove` / `account remove` — cleanup succeeded.
  - `binding list` — query accepted by the schema (no existing bindings locally to exercise the `executionConfig` round-trip on add/update).
  - All test data created during manual verification was removed afterward; no residue left in the shared local deploy.
  - Note: `account-group add` requires `--region` for AWS groups — pre-existing server-side validation unrelated to this migration, just something to be aware of when testing.
  - Not yet exercised manually: `repository add` (needs a reachable git URL) and `binding add`/`update` (no binding fixture available locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
